### PR TITLE
Fix/generate chunk default value

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ PynkTromboneEnvは人間のVocal Tractをシミュレーションし、強化学
     基準となる声の高さです。この周波数から上下1オクターブが生成可能な周波数帯です。
 
 - generate_chunk: int  
-    1ステップで生成する音声波形の長さです。pynkTromboneではデフォルトで`512`です。
+    1ステップで生成する音声波形の長さです。pynkTromboneではデフォルトで`1024`です。
 - stft_window_size: int  
     波形をstftする時のウィンドウサイズです。デフォルトでは`1024`です。
 

--- a/pynktrombonegym/env.py
+++ b/pynktrombonegym/env.py
@@ -32,7 +32,7 @@ class PynkTrombone(gym.Env):
         target_sound_files: Sequence[str],
         sample_rate: int = 44100,
         default_frequency: float = 400.0,
-        generate_chunk: int = 512,
+        generate_chunk: int = 1024,
         stft_window_size: int = 1024,
         stft_hop_length: int = None,
     ):

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -24,7 +24,7 @@ def test__init__():
     assert default.target_sound_files == target_sound_files
     assert default.sample_rate == 44100
     assert default.default_frequency == 400
-    assert default.generate_chunk == 512
+    assert default.generate_chunk == 1024
     assert default.stft_window_size == 1024
     assert default.stft_hop_length == 256
 


### PR DESCRIPTION
#66 Fix default value of `generate_chunk` to 1024 because librosa warns previous default (512) is too small for n_fft length 1024.