### PR TITLE
Renderer/to voc renderer

### DIFF
--- a/pynktrombonegym/renderer.py
+++ b/pynktrombonegym/renderer.py
@@ -1,46 +1,39 @@
 import matplotlib.pyplot as plt
 import numpy as np
-
-from .env import PynkTrombone
+from pynktrombone.voc import Voc
 
 
 class Renderer:
     """Render process of PynkTrombone environment.
 
     Plotting:
-    - current_step
     - current_tract_diameters
     - nose_diameters
     - current voc frequency
     - current voc tenseness
     """
 
-    def __init__(self, env: PynkTrombone, figsize: tuple[float, float] = (6.4, 4.8)) -> None:
+    def __init__(self, voc: Voc, figsize: tuple[float, float] = (6.4, 4.8)) -> None:
         """Construct Renderer and create intial figure and etc...
         Args:
-            env (PynkTrombone): PynkTrombone vocal tract environment model.
+            voc (Voc): vocal tract model.
             figsize (tuple[float, float]): Figure size of rendered image. [Inch]
         """
 
-        self.env = env
+        self.voc = voc
         self.figsize = figsize
         self.create_initial_components()
 
     def make_infomation_text(self) -> str:
         """Make infomation text displaying on the figure.
         Infomations are:
-            - current_step
             - frequency
             - tenseness
 
         Returns:
             info_text (str): Infomation text value.
         """
-        info = (
-            f"current step: {self.env.current_step}\n"
-            f"frequency: {float(self.env.voc.frequency): .2f}\n"
-            f"tenseness: {float(self.env.voc.tenseness): .2f}\n"
-        )
+        info = f"frequency: {float(self.voc.frequency): .2f}\n" f"tenseness: {float(self.voc.tenseness): .2f}\n"
 
         return info
 
@@ -49,14 +42,14 @@ class Renderer:
         Componentes are Figure, axes, lines, and etc...
         """
 
-        nose_diameters = self.env.voc.nose_diameters
-        currect_tract_diameters = self.env.voc.current_tract_diameters
+        nose_diameters = self.voc.nose_diameters
+        currect_tract_diameters = self.voc.current_tract_diameters
 
         self.figure = plt.figure(figsize=self.figsize)
         self.axes = self.figure.add_subplot(1, 1, 1)
 
-        self.indices = list(range(self.env.voc.tract_size))
-        self.nose_indices = self.indices[-self.env.voc.nose_size :]
+        self.indices = list(range(self.voc.tract_size))
+        self.nose_indices = self.indices[-self.voc.nose_size :]
 
         self.axes.set_ylim(0.0, 5.0)
         self.nose_diameters_line = self.axes.plot(self.nose_indices, nose_diameters, label="nose diameters")[0]
@@ -73,8 +66,8 @@ class Renderer:
 
     def update_values(self) -> None:
         """Update values ploted on the figure."""
-        nose_diameters = self.env.voc.nose_diameters
-        currect_tract_diameters = self.env.voc.current_tract_diameters
+        nose_diameters = self.voc.nose_diameters
+        currect_tract_diameters = self.voc.current_tract_diameters
 
         info_text = self.make_infomation_text()
         self.tract_diameters_line.set_data(self.indices, currect_tract_diameters)

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -1,49 +1,43 @@
 import matplotlib.pyplot as plt
 import numpy as np
 from matplotlib import lines, text
+from pynktrombone.voc import Voc
 
 from pynktrombonegym import renderer
-from pynktrombonegym.env import PynkTrombone
-
-from .test_env import target_sound_files
 
 
 def test__init__():
-    dflt = PynkTrombone(target_sound_files)
-    rndr = renderer.Renderer(dflt)
+    voc = Voc()
+    rndr = renderer.Renderer(voc)
 
-    assert rndr.env is dflt
+    assert rndr.voc is voc
     assert rndr.figsize == (6.4, 4.8)
 
-    rndr = renderer.Renderer(dflt, figsize=(1, 1))
-    assert rndr.env is dflt
+    rndr = renderer.Renderer(voc, figsize=(1, 1))
+    assert rndr.voc is voc
     assert rndr.figsize == (1, 1)
 
 
 def test_make_infomation_text():
-    dflt = PynkTrombone(target_sound_files)
-    rndr = renderer.Renderer(dflt)
+    voc = Voc()
+    rndr = renderer.Renderer(voc)
 
     info_text = rndr.make_infomation_text()
 
-    correct = (
-        f"current step: {dflt.current_step}\n"
-        f"frequency: {float(dflt.voc.frequency): .2f}\n"
-        f"tenseness: {float(dflt.voc.tenseness): .2f}\n"
-    )
+    correct = f"frequency: {float(voc.frequency): .2f}\n" f"tenseness: {float(voc.tenseness): .2f}\n"
 
     assert info_text == correct
 
 
 def test_create_initial_components():
-    dflt = PynkTrombone(target_sound_files)
-    rndr = renderer.Renderer(dflt)
+    voc = Voc()
+    rndr = renderer.Renderer(voc)
     # called in `__init__`
 
     assert isinstance(rndr.figure, plt.Figure)
     assert isinstance(rndr.axes, plt.Axes)
-    assert rndr.indices == list(range(dflt.voc.tract_size))
-    assert rndr.nose_indices == rndr.indices[-dflt.voc.nose_size :]
+    assert rndr.indices == list(range(voc.tract_size))
+    assert rndr.nose_indices == rndr.indices[-voc.nose_size :]
     assert isinstance(rndr.nose_diameters_line, lines.Line2D)
     assert isinstance(rndr.tract_diameters_line, lines.Line2D)
     assert isinstance(rndr.infomation_text, text.Text)
@@ -52,12 +46,13 @@ def test_create_initial_components():
 
 
 def test_update_values():
-    dflt = PynkTrombone(target_sound_files)
-    rndr = renderer.Renderer(dflt)
+    voc = Voc()
+    rndr = renderer.Renderer(voc)
 
-    dflt.reset()
-    action = dflt.action_space.sample()
-    dflt.step(action)
+    voc.frequency = voc.frequency + 10
+    voc.tenseness = 0.44
+    voc.set_tract_parameters(0.7, 0.5, 0.1, 29, 1.0, 1.0)
+    voc.step()
 
     rndr.update_values()
 
@@ -67,8 +62,8 @@ def test_update_values():
 
 
 def test_fig2rgba_array():
-    dflt = PynkTrombone(target_sound_files)
-    rndr = renderer.Renderer(dflt)
+    voc = Voc()
+    rndr = renderer.Renderer(voc)
 
     array = rndr.fig2rgba_array(rndr.figure)
 
@@ -83,8 +78,8 @@ def test_fig2rgba_array():
 
 
 def test_fig2rgb_array():
-    dflt = PynkTrombone(target_sound_files)
-    rndr = renderer.Renderer(dflt)
+    voc = Voc()
+    rndr = renderer.Renderer(voc)
 
     array = rndr.fig2rgb_array(rndr.figure)
 
@@ -94,8 +89,8 @@ def test_fig2rgb_array():
 
 
 def test_render_rgb_array():
-    dflt = PynkTrombone(target_sound_files)
-    rndr = renderer.Renderer(dflt)
+    voc = Voc()
+    rndr = renderer.Renderer(voc)
 
     array = rndr.render_rgb_array()
 
@@ -107,9 +102,9 @@ def test_render_rgb_array():
 
 
 def test_close():
-    dflt = PynkTrombone(target_sound_files)
+    voc = Voc()
     fignum_before_create = len(plt.get_fignums())
-    rndr = renderer.Renderer(dflt)
+    rndr = renderer.Renderer(voc)
     fignum_after_create = len(plt.get_fignums())
     axnum = len(rndr.figure.axes)
 
@@ -123,9 +118,9 @@ def test_close():
 
 
 def test__del__():
-    dflt = PynkTrombone(target_sound_files)
+    voc = Voc()
     fignum_before_create = len(plt.get_fignums())
-    rndr = renderer.Renderer(dflt)
+    rndr = renderer.Renderer(voc)
     fignum_after_create = len(plt.get_fignums())
 
     assert fignum_before_create + 1 == fignum_after_create


### PR DESCRIPTION
#81 #130 https://github.com/Geson-anko/PynkTromboneGym/issues/130#issuecomment-1256840395
`PynkTrombone`環境モデルを直接受け取らず、`Voc`クラスを直接受け取るようにしました。
以下の項目を変更しました。
- `__init__`の第一引数を`env`から`voc`へ。
- make_information_textから`current_step`を除外
- `self.env.voc` -> `self.voc`
- それに伴うテストコードの修正