### PR TITLE
Fix dependencies field

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,8 @@ gym = "^0.25.2"
 pynktrombone = {git = "https://github.com/Geson-anko/pynktrombone.git", rev = "master"}
 matplotlib = "^3.5.3"
 pydub = "^0.25.1"
+scipy = "^1.9.1"
+librosa = "^0.9.2"
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.0"
@@ -17,8 +19,6 @@ pyproject-flake8 = "^0.0.1-alpha.5"
 black = "^22.6.0"
 isort = "^5.10.1"
 mypy = "^0.971"
-scipy = "^1.9.1"
-librosa = "^0.9.2"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]


### PR DESCRIPTION
Move scipy and librosa to `tool.poetry.dependencies` from `tool.poetry.dev-dependencies`