### PR TITLE
load_sound_file using librosa

### DIFF
--- a/pynktrombonegym/spectrogram.py
+++ b/pynktrombonegym/spectrogram.py
@@ -4,7 +4,6 @@ from typing import Any, Literal
 
 import librosa
 import numpy as np
-from pydub import AudioSegment
 
 padT = Literal[
     "constant", "edge", "linear_ramp", "maximum", "mean", "median", "minimum", "reflect", "symmetric", "wrap", "empty"
@@ -67,17 +66,9 @@ def load_sound_file(file_path: Any, sample_rate: int) -> np.ndarray:
             Waveform of loaded sound.
     """
 
-    sound: AudioSegment = AudioSegment.from_file(file_path)
+    waveform, _ = librosa.load(file_path, sr=sample_rate, mono=True, dtype=np.float32)
 
-    if sound.frame_rate != sample_rate:
-        sound = sound.set_frame_rate(sample_rate)
-    if sound.channels != 1:
-        sound = sound.set_channels(1)
-
-    max_value = 2 ** (8 * sound.sample_width)
-    wave = np.array(sound.get_array_of_samples()).reshape(-1) / max_value
-    wave = wave.astype(np.float32)
-    return wave
+    return waveform
 
 
 def pad_tail(wave: np.ndarray, target_length: int, padding_mode: padT = "constant", **kwds) -> np.ndarray:


### PR DESCRIPTION
Fix for Issue #149 

Since the library is already using `librosa`, reimplemented `load_sound_file` using `librosa.load`.
We would need to rely on heuristics to understand the right sampling and normalization of the audio file.

## Testing
```bash pytest tests/test_spectrogram.py
platform linux -- Python 3.10.12, pytest-8.0.2, pluggy-1.4.0
rootdir: /home/sandeepnmenon/github/PynkTromboneGym
configfile: pyproject.toml
collected 5 items                                                                                                                                                                                     

tests/test_spectrogram.py .....                                                                                                                                                                 [100%]

========================================================================================== 5 passed in 1.13s ==========================================================================================
```
